### PR TITLE
Remove typing dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,6 @@ install_requires = [
     'scikit-learn',
     'scipy',
     'tqdm',
-    'typing'
 ]
 
 


### PR DESCRIPTION
We don't support python2 and it has difficulty in installing in python3.7.